### PR TITLE
Implement mp3 to wav bytestream functionality

### DIFF
--- a/link_handler.py
+++ b/link_handler.py
@@ -4,6 +4,9 @@ store information in the database.
 """
 import os
 import pytube
+import wave
+import struct
+from pydub import AudioSegment
 
 MAX_LENGTH = 10 # maximum supported video length in minutes
 
@@ -61,3 +64,49 @@ def clean_link(link):
     if len(link_split) == 2:
         return link_split[1]
     return link
+
+def convert_mp3_to_wav(path):
+    """Given a relative path to a .mp3 audio file, converts the audio to .wav
+    format. Must export .mp3 to .wav file first, before sampling .wav. Then .wav
+    file can be deleted from directory.
+    Arguments:
+        path: String relative path to .mp3 file
+    Returns: List of sampled audio from .wav file at 16 bits per sample
+    """
+    # Extract the filename of the mp3 from the path
+    filename = path.split("/audio_files/",1)[1]
+    filename = filename.split(".mp3",1)[0]
+    filename_wav = "{}.wav".format(filename)
+    samples = []
+
+    # In some cases the dependency ffmpeg will misread a .mp3 file, and requires a .mp4 container
+    # https://stackoverflow.com/questions/70660431/couldntdecodeerror-decoding-failed-ffmpeg-returned-error-code-69
+    try:
+        sound = AudioSegment.from_file(path, "mp3")
+    except:
+        sound = AudioSegment.from_file(path, format="mp4")
+
+    # Export the sound into a .wav file in the root folder to be read
+    sound.export(filename_wav, format="wav")
+
+    # Use wave to read .wav file and extract samples to array
+    if os.path.exists(filename_wav):
+        # Read all of the frames from the .wav file and place into a bytestring
+        audio_wav = wave.open(filename_wav, 'rb')
+        nframes = audio_wav.getnframes()
+        bytestring = audio_wav.readframes(audio_wav.getnframes())
+
+        # By default, the .wav file is read from at 32 bits at a time, so
+        # unpack into 2 16 bit integers and add to samples both integers
+        for frame in range(nframes):
+            ind = 4*frame
+            samples += list(struct.unpack("<hh", bytestring[ind:ind+4]))
+
+        # Close the connection to the .wav file
+        audio_wav.close()
+
+        # Delete the .wav file as no longer needed
+        os.remove(filename_wav)
+
+    # Return the list of 2-byte integer samples of the audio for future processing/streaming
+    return samples

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytube3
 pytube
+pydub


### PR DESCRIPTION
Added function to link_handler.py that given a relative path, returns a list of 2-byte integers that represents the audio from the .mp3 file. 

To do this, need to create a .wav file from the .mp3 file, and separately read from the .wav file, converting every 2 bytes into integers. 

For this to work, ffmpeg must be installed onto the device that runs the script as well, as pydub has a dependency on ffmpeg, and ffmpeg from a pip3 install alone has no executables. It must be installed via homebrew or the module's website.