### PR TITLE
Add threaded queue for commands in music_server, fix indexing bug

### DIFF
--- a/nicer_rack_web/server/api.py
+++ b/nicer_rack_web/server/api.py
@@ -108,7 +108,12 @@ def handle_queue():
                 for song in queue:
                     song['index'] -= 1
                 
-                # Update state variables for queue checking
+                # If queue empty after song ends, end queue handling
+                if not len(queue):
+                    queue_lock.notify()
+                    break
+
+                # Update state variables for queue checking for next song
                 next_song_sent = False
                 next_song_link = None
                 curr_song_start = time.time()


### PR DESCRIPTION
To control the order of commands run when received over the socket, socket places received messages into a threaded command queue in music_server.py. This ensures that every loop within the web_serv_func initiates the next command sequentially as received from the API. This fixes bugs caused by skipping songs quickly on the UI.

Also fixed an indexing bug that would occur whenever the last song on the queue played through, which would cause the queue to stop working. Queue appears to be fully functional now, haven't yet tested with audio however.